### PR TITLE
Add simple SCORM player

### DIFF
--- a/courses/sample-course/index.html
+++ b/courses/sample-course/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sample SCORM Course</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pipwerks-scorm-api-wrapper/1.1.20130508/pipwerks-scorm-api-wrapper.min.js"></script>
+</head>
+<body>
+    <h1>Welcome to the Sample SCORM Course</h1>
+    <p>This is a minimal example course.</p>
+
+    <script>
+    var scorm = pipwerks.SCORM;
+    scorm.version = "1.2";
+    if(scorm.init()){
+        scorm.set("cmi.core.lesson_status", "completed");
+        scorm.save();
+        console.log("Lesson marked as completed");
+    }
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
                 <li><a href="#about">אודות</a></li>
                 <li><a href="#projects">פרויקטים</a></li>
                 <li><a href="#blog">בלוג</a></li>
+                <li><a href="scorm-player.html">קורסים</a></li>
                 <li><a href="#contact">צור קשר</a></li>
             </ul>
         </nav>

--- a/scorm-player.html
+++ b/scorm-player.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SCORM Player</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- SCORM API Wrapper from pipwerks -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pipwerks-scorm-api-wrapper/1.1.20130508/pipwerks-scorm-api-wrapper.min.js"></script>
+</head>
+<body>
+    <header>
+        <nav class="container">
+            <div class="logo">SCORM LMS</div>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main class="container" style="padding-top: 60px;">
+        <h1>Load SCORM Course</h1>
+        <form id="load-course-form">
+            <label for="courseUrl">SCORM Course URL:</label>
+            <input type="text" id="courseUrl" placeholder="courses/sample-course/index.html" style="width:100%;max-width:400px;">
+            <button type="submit" class="cta-button" style="margin-top:10px;">Load</button>
+        </form>
+        <div id="course-container" style="margin-top:20px;">
+            <iframe id="scormFrame" width="100%" height="600" src=""></iframe>
+        </div>
+    </main>
+
+    <script>
+    const scorm = pipwerks.SCORM;
+    scorm.version = "1.2"; // or "2004" depending on your courses
+
+    document.getElementById('load-course-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        const frame = document.getElementById('scormFrame');
+        const url = document.getElementById('courseUrl').value.trim();
+        if(!url) return;
+        frame.src = url;
+        if(scorm.init()){
+            console.log('SCORM initialized');
+        } else {
+            console.warn('SCORM initialization failed');
+        }
+    });
+
+    window.addEventListener('beforeunload', function(){
+        scorm.quit();
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add nav link to new SCORM player page
- implement `scorm-player.html` for loading SCORM courses
- include a minimal sample SCORM course

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684177259e48833381bbac7cd3d5154e